### PR TITLE
Beem to nectar

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ apt-get install libmariadbclient-dev
 ```
 
 ```
-pip3 install beem dataset  mysqlclient
+pip3 install hive-nectar dataset  mysqlclient
 ```
 
 Compile and install steembi, the helper library for all steembasicincome scripts

--- a/sbi_build_member_db.py
+++ b/sbi_build_member_db.py
@@ -1,9 +1,9 @@
-from beem.account import Account
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
-from beem.utils import formatTimeString
+from nectar.account import Account
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
+from nectar.utils import formatTimeString
 import re
 import json
 import os

--- a/sbi_check_delegation.py
+++ b/sbi_check_delegation.py
@@ -1,9 +1,9 @@
-from beem.account import Account
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.utils import formatTimeString
-from beem.nodelist import NodeList
+from nectar.account import Account
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.utils import formatTimeString
+from nectar.nodelist import NodeList
 import re
 import os
 from time import sleep

--- a/sbi_check_member_db.py
+++ b/sbi_check_member_db.py
@@ -1,9 +1,9 @@
-from beem.account import Account
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
-from beem.utils import formatTimeString
+from nectar.account import Account
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
+from nectar.utils import formatTimeString
 import re
 import json
 import os

--- a/sbi_check_ops_db.py
+++ b/sbi_check_ops_db.py
@@ -1,10 +1,10 @@
-from beem.account import Account
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
-from beem.blockchain import Blockchain
-from beem.utils import formatTimeString, addTzInfo
+from nectar.account import Account
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
+from nectar.blockchain import Blockchain
+from nectar.utils import formatTimeString, addTzInfo
 from datetime import datetime
 import re
 import os

--- a/sbi_check_promotion_post.py
+++ b/sbi_check_promotion_post.py
@@ -1,16 +1,16 @@
-from beem.account import Account
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
-from beem.utils import addTzInfo, resolve_authorperm, formatTimeString
-from beem.vote import AccountVotes
-from beem.comment import Comment
-from beem.block import Block
-from beem.blockchain import Blockchain
-from beem.wallet import Wallet
-from beembase.signedtransactions import Signed_Transaction
-from beemgraphenebase.base58 import Base58
+from nectar.account import Account
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
+from nectar.utils import addTzInfo, resolve_authorperm, formatTimeString
+from nectar.vote import AccountVotes
+from nectar.comment import Comment
+from nectar.block import Block
+from nectar.blockchain import Blockchain
+from nectar.wallet import Wallet
+from nectarbase.signedtransactions import Signed_Transaction
+from nectargraphenebase.base58 import Base58
 from datetime import datetime, timedelta
 import re
 import json

--- a/sbi_check_trx_database.py
+++ b/sbi_check_trx_database.py
@@ -1,8 +1,8 @@
-from beem.account import Account
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
+from nectar.account import Account
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
 import re
 import os
 import dataset

--- a/sbi_compare_ops_db.py
+++ b/sbi_compare_ops_db.py
@@ -1,10 +1,10 @@
-from beem.account import Account
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
-from beem.blockchain import Blockchain
-from beem.utils import formatTimeString, addTzInfo
+from nectar.account import Account
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
+from nectar.blockchain import Blockchain
+from nectar.utils import formatTimeString, addTzInfo
 from datetime import datetime
 import re
 import os

--- a/sbi_maintainance.py
+++ b/sbi_maintainance.py
@@ -1,12 +1,12 @@
-from beem.account import Account
-from beem.comment import Comment
-from beem.vote import ActiveVotes
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
-from beem.memo import Memo
-from beem.utils import addTzInfo, resolve_authorperm, formatTimeString, construct_authorperm
+from nectar.account import Account
+from nectar.comment import Comment
+from nectar.vote import ActiveVotes
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
+from nectar.memo import Memo
+from nectar.utils import addTzInfo, resolve_authorperm, formatTimeString, construct_authorperm
 from datetime import datetime, timedelta
 import requests
 import re

--- a/sbi_reset_rshares.py
+++ b/sbi_reset_rshares.py
@@ -1,16 +1,16 @@
-from beem.account import Account
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
-from beem.utils import addTzInfo, resolve_authorperm, formatTimeString, construct_authorperm
-from beem.vote import AccountVotes
-from beem.comment import Comment
-from beem.block import Block
-from beem.blockchain import Blockchain
-from beem.wallet import Wallet
-from beembase.signedtransactions import Signed_Transaction
-from beemgraphenebase.base58 import Base58
+from nectar.account import Account
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
+from nectar.utils import addTzInfo, resolve_authorperm, formatTimeString, construct_authorperm
+from nectar.vote import AccountVotes
+from nectar.comment import Comment
+from nectar.block import Block
+from nectar.blockchain import Blockchain
+from nectar.wallet import Wallet
+from nectarbase.signedtransactions import Signed_Transaction
+from nectargraphenebase.base58 import Base58
 from datetime import datetime, timedelta
 import re
 import json

--- a/sbi_store_member_hist.py
+++ b/sbi_store_member_hist.py
@@ -1,12 +1,12 @@
-from beem.account import Account
-from beem.amount import Amount
-from beem.comment import Comment
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
-from beem.blockchain import Blockchain
-from beem.vote import Vote
-from beem.utils import formatTimeString, addTzInfo, construct_authorperm
+from nectar.account import Account
+from nectar.amount import Amount
+from nectar.comment import Comment
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
+from nectar.blockchain import Blockchain
+from nectar.vote import Vote
+from nectar.utils import formatTimeString, addTzInfo, construct_authorperm
 from datetime import datetime, timedelta
 import re
 import time

--- a/sbi_store_ops_db.py
+++ b/sbi_store_ops_db.py
@@ -1,10 +1,10 @@
-from beem.account import Account
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
-from beem.blockchain import Blockchain
-from beem.utils import formatTimeString, addTzInfo
+from nectar.account import Account
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
+from nectar.blockchain import Blockchain
+from nectar.utils import formatTimeString, addTzInfo
 from datetime import datetime
 import re
 import os

--- a/sbi_stream_post_comment.py
+++ b/sbi_stream_post_comment.py
@@ -1,11 +1,11 @@
-from beem.utils import formatTimeString, resolve_authorperm, construct_authorperm, addTzInfo
-from beem.nodelist import NodeList
-from beem.comment import Comment
-from beem import Steem
-from beem import Hive
+from nectar.utils import formatTimeString, resolve_authorperm, construct_authorperm, addTzInfo
+from nectar.nodelist import NodeList
+from nectar.comment import Comment
+from nectar import Steem
+from nectar import Hive
 from datetime import datetime, timedelta
-from beem.instance import set_shared_steem_instance
-from beem.blockchain import Blockchain
+from nectar.instance import set_shared_steem_instance
+from nectar.blockchain import Blockchain
 import time 
 import json
 import os
@@ -14,7 +14,7 @@ import dataset
 import random
 from datetime import date, datetime, timedelta
 from dateutil.parser import parse
-from beem.constants import STEEM_100_PERCENT, HIVE_100_PERCENT 
+from nectar.constants import STEEM_100_PERCENT, HIVE_100_PERCENT 
 from steembi.transfer_ops_storage import TransferTrx, AccountTrx, PostsTrx
 from steembi.storage import TrxDB, MemberDB, ConfigurationDB, AccountsDB, KeysDB, BlacklistDB
 from steembi.parse_hist_op import ParseAccountHist

--- a/sbi_stream_test_data.py
+++ b/sbi_stream_test_data.py
@@ -1,10 +1,10 @@
-from beem.account import Account
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
-from beem.blockchain import Blockchain
-from beem.utils import formatTimeString, addTzInfo
+from nectar.account import Account
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
+from nectar.blockchain import Blockchain
+from nectar.utils import formatTimeString, addTzInfo
 from datetime import datetime
 import re
 import os

--- a/sbi_transfer.py
+++ b/sbi_transfer.py
@@ -1,9 +1,9 @@
-from beem.account import Account
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
-from beem.utils import formatTimeString
+from nectar.account import Account
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
+from nectar.utils import formatTimeString
 import re
 import os
 import json

--- a/sbi_update_curation_rshares.py
+++ b/sbi_update_curation_rshares.py
@@ -1,12 +1,12 @@
-from beem.account import Account
-from beem.comment import Comment
-from beem.vote import ActiveVotes
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
-from beem.memo import Memo
-from beem.utils import addTzInfo, resolve_authorperm, formatTimeString, construct_authorperm
+from nectar.account import Account
+from nectar.comment import Comment
+from nectar.vote import ActiveVotes
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
+from nectar.memo import Memo
+from nectar.utils import addTzInfo, resolve_authorperm, formatTimeString, construct_authorperm
 from datetime import datetime, timedelta
 import requests
 import re

--- a/sbi_update_member_db.py
+++ b/sbi_update_member_db.py
@@ -1,12 +1,12 @@
-from beem.account import Account
-from beem.comment import Comment
-from beem.vote import ActiveVotes
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
-from beem.memo import Memo
-from beem.utils import addTzInfo, resolve_authorperm, formatTimeString, construct_authorperm
+from nectar.account import Account
+from nectar.comment import Comment
+from nectar.vote import ActiveVotes
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
+from nectar.memo import Memo
+from nectar.utils import addTzInfo, resolve_authorperm, formatTimeString, construct_authorperm
 from datetime import datetime, timedelta
 import requests
 import re

--- a/sbi_update_member_db.py.save
+++ b/sbi_update_member_db.py.save
@@ -1,14 +1,14 @@
 ^571
-from beem.account import Account
+from nectar.account import Account
 _
-from beem.comment import Comment
-from beem.vote import ActiveVotes
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
-from beem.memo import Memo
-from beem.utils import addTzInfo, resolve_authorperm, formatTimeString, construct_authorperm
+from nectar.comment import Comment
+from nectar.vote import ActiveVotes
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
+from nectar.memo import Memo
+from nectar.utils import addTzInfo, resolve_authorperm, formatTimeString, construct_authorperm
 from datetime import datetime, timedelta
 import requests
 import re

--- a/sbi_update_trx_database.py
+++ b/sbi_update_trx_database.py
@@ -1,8 +1,8 @@
-from beem.account import Account
-from beem.amount import Amount
-from beem import Steem
-from beem.instance import set_shared_steem_instance
-from beem.nodelist import NodeList
+from nectar.account import Account
+from nectar.amount import Amount
+from nectar import Steem
+from nectar.instance import set_shared_steem_instance
+from nectar.nodelist import NodeList
 import re
 import os
 from time import sleep

--- a/sbi_upvote_post_comment.py
+++ b/sbi_upvote_post_comment.py
@@ -1,13 +1,13 @@
-from beem.utils import formatTimeString, resolve_authorperm, construct_authorperm, addTzInfo
-from beem.nodelist import NodeList
-from beem.comment import Comment
-from beem import Hive
-from beem import Steem
+from nectar.utils import formatTimeString, resolve_authorperm, construct_authorperm, addTzInfo
+from nectar.nodelist import NodeList
+from nectar.comment import Comment
+from nectar import Hive
+from nectar import Steem
 from datetime import datetime, timedelta
-from beem.instance import set_shared_steem_instance
-from beem.blockchain import Blockchain
-from beem.account import Account
-from beem.vote import Vote
+from nectar.instance import set_shared_steem_instance
+from nectar.blockchain import Blockchain
+from nectar.account import Account
+from nectar.vote import Vote
 import time 
 import json
 import os
@@ -15,7 +15,7 @@ import math
 import dataset
 from datetime import date, datetime, timedelta
 from dateutil.parser import parse
-from beem.constants import HIVE_100_PERCENT, STEEM_100_PERCENT
+from nectar.constants import HIVE_100_PERCENT, STEEM_100_PERCENT
 from steembi.transfer_ops_storage import TransferTrx, AccountTrx, PostsTrx
 from steembi.storage import TrxDB, MemberDB, ConfigurationDB, AccountsDB, KeysDB
 from steembi.parse_hist_op import ParseAccountHist

--- a/sbirunner.sh
+++ b/sbirunner.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 hive-nectar updatenodes --hive
 
-/usr/local/bin/python3.6 -u /root/steembasicincome/sbi_store_ops_db.py
-/usr/local/bin/python3.6 -u /root/steembasicincome/sbi_transfer.py
-/usr/local/bin/python3.6 -u /root/steembasicincome/sbi_check_delegation.py
-#/usr/local/bin/python3.6 -u /root/steembasicincome/sbi_update_curation_rshares.py
-/usr/local/bin/python3.6 -u /root/steembasicincome/sbi_update_member_db.py
+python3 -u /root/steembasicincome/sbi_store_ops_db.py
+python3 -u /root/steembasicincome/sbi_transfer.py
+python3 -u /root/steembasicincome/sbi_check_delegation.py
+#python3 -u /root/steembasicincome/sbi_update_curation_rshares.py
+python3 -u /root/steembasicincome/sbi_update_member_db.py
 
-/usr/local/bin/python3.6 -u /root/steembasicincome/sbi_store_member_hist.py
-/usr/local/bin/python3.6 -u /root/steembasicincome/sbi_upvote_post_comment.py
+python3 -u /root/steembasicincome/sbi_store_member_hist.py
+python3 -u /root/steembasicincome/sbi_upvote_post_comment.py
 
-/usr/local/bin/python3.6 -u /root/steembasicincome/sbi_stream_post_comment.py
+python3 -u /root/steembasicincome/sbi_stream_post_comment.py
 
 
 
-#/usr/local/bin/python3.6 -u /root/steembasicincome/sbi_reset_rshares.py
+#python3 -u /root/steembasicincome/sbi_reset_rshares.py

--- a/sbirunner.sh
+++ b/sbirunner.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-beempy updatenodes --hive
+hive-nectar updatenodes --hive
 
 /usr/local/bin/python3.6 -u /root/steembasicincome/sbi_store_ops_db.py
 /usr/local/bin/python3.6 -u /root/steembasicincome/sbi_transfer.py

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Packaging logic for beem."""
+"""Packaging logic for nectar."""
 import codecs
 import io
 import os
@@ -21,7 +21,7 @@ VERSION = '0.1.2'
 tests_require = ['mock >= 2.0.0', 'pytest', 'pytest-mock', 'parameterized']
 
 requires = [
-    "beem",
+    "nectar",
     "dataset",
     "mysqlclient"
 ]
@@ -29,7 +29,7 @@ requires = [
 
 def write_version_py(filename):
     """Write version."""
-    cnt = """\"""THIS FILE IS GENERATED FROM beem SETUP.PY.\"""
+    cnt = """\"""THIS FILE IS GENERATED FROM nectar SETUP.PY.\"""
 version = '%(version)s'
 """
     with open(filename, 'w') as a:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ VERSION = '0.1.2'
 tests_require = ['mock >= 2.0.0', 'pytest', 'pytest-mock', 'parameterized']
 
 requires = [
-    "nectar",
+    "hive-nectar",
     "dataset",
     "mysqlclient"
 ]


### PR DESCRIPTION
This should be a 1:1 version using hive-nectar in place of beem. You would have to `pip uninstall beem` and `pip install hive-nectar` but the issue is the python version is **old** for nectar which officially list 3.10 as the earliest version it has tested against and hsbi is running against 3.6.